### PR TITLE
Feat/custom html output format

### DIFF
--- a/index.js
+++ b/index.js
@@ -629,23 +629,28 @@ const saveAsHtml = async ({ page, filePath, options, route, fs }) => {
   const minifiedContent = options.minifyHtml
     ? minify(content, options.minifyHtml)
     : content;
+  const isRootRoute = route == '/'
+  const hasTrailingSlash = route.endsWith('/')
+
   filePath = filePath.replace(/\//g, path.sep);
 
-  if (route.endsWith('/') && route !== '/') {
+  // remove trailing / to prevent saving with filename '/route.html'
+  if (hasTrailingSlash && !isRootRoute) {
     filePath = filePath.slice(0, -1)
     route = route.slice(0, -1)
   }
 
-  if (route.endsWith(".html") || (options.useRouteAsFileName && route !== "/")) {
+  // saving as 200.html, 404.html
+  // if useRouteAsFileName: route1.html, route2.html...
+  if (route.endsWith(".html") || (options.useRouteAsFileName && !isRootRoute)) {
     if (route.endsWith("/404.html") && !title.includes("404"))
       console.log('⚠️  warning: 404 page title does not contain "404" string');
     mkdirp.sync(path.dirname(filePath));
-    if (!route.endsWith(".html")) {
-      fs.writeFileSync(`${filePath}.html`, minifiedContent);
-    } else {
-      fs.writeFileSync(filePath, minifiedContent);
-    }
+
+    const outputPath = route.endsWith(".html") ? filePath :  `${filePath}.html`
+    fs.writeFileSync(outputPath, minifiedContent);
   } else {
+    // saving as route1/index.html, route2/index.html...
     if (title.includes("404"))
       console.log(`⚠️  warning: page not found ${route}`);
     mkdirp.sync(filePath);

--- a/index.js
+++ b/index.js
@@ -66,6 +66,9 @@ const defaultOptions = {
   inlineCss: false,
   //# feature creeps to generate screenshots
   saveAs: "html",
+  // if true latest path becomes file name: '{route}.html' instead of 'route/index.html'
+  // or 'path/to/{route}.html' instead of 'path/to/route/index.html'
+  useRouteAsFileName: false,
   crawl: true,
   waitFor: false,
   externalServer: false,
@@ -627,11 +630,21 @@ const saveAsHtml = async ({ page, filePath, options, route, fs }) => {
     ? minify(content, options.minifyHtml)
     : content;
   filePath = filePath.replace(/\//g, path.sep);
-  if (route.endsWith(".html")) {
+
+  if (route.endsWith('/') && route !== '/') {
+    filePath = filePath.slice(0, -1)
+    route = route.slice(0, -1)
+  }
+
+  if (route.endsWith(".html") || (options.useRouteAsFileName && route !== "/")) {
     if (route.endsWith("/404.html") && !title.includes("404"))
       console.log('⚠️  warning: 404 page title does not contain "404" string');
     mkdirp.sync(path.dirname(filePath));
-    fs.writeFileSync(filePath, minifiedContent);
+    if (!route.endsWith(".html")) {
+      fs.writeFileSync(`${filePath}.html`, minifiedContent);
+    } else {
+      fs.writeFileSync(filePath, minifiedContent);
+    }
   } else {
     if (title.includes("404"))
       console.log(`⚠️  warning: page not found ${route}`);

--- a/tests/__snapshots__/defaultOptions.test.js.snap
+++ b/tests/__snapshots__/defaultOptions.test.js.snap
@@ -46,6 +46,7 @@ Object {
   "skipThirdPartyRequests": false,
   "source": "build",
   "sourceMaps": true,
+  "useRouteAsFileName": false,
   "userAgent": "ReactSnap",
   "viewport": Object {
     "height": 850,

--- a/tests/examples/complex-routes/index.html
+++ b/tests/examples/complex-routes/index.html
@@ -1,0 +1,19 @@
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <link rel="alternate" href='/5' />
+</head>
+
+<body>
+  <a href="#section">go to section</a>
+  <a href="/1/path">1</a>
+  <a href="/2/path/to">2</a>
+  <a href="/3#test">3</a>
+  <a href="/4?test">4</a>
+  <script>
+    document.body.appendChild(document.createTextNode("test"));
+  </script>
+</body>
+
+</html>

--- a/tests/examples/complex-routes/index.html
+++ b/tests/examples/complex-routes/index.html
@@ -10,7 +10,10 @@
   <a href="/1/path">1</a>
   <a href="/2/path/to">2</a>
   <a href="/3#test">3</a>
+  <a href="/3#test">3</a>
   <a href="/4?test">4</a>
+  <a href="/6">4</a>
+  <a href="/6/subroute">4</a>
   <script>
     document.body.appendChild(document.createTextNode("test"));
   </script>

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -243,7 +243,7 @@ describe("complex routes", () => {
   beforeAll(() => snapRun(fs, { source }));
 
   test("crawls all links and saves as index.html in separate folders", () => {
-    expect(filesCreated()).toEqual(7);
+    expect(filesCreated()).toEqual(9);
     expect(names()).toEqual(
       expect.arrayContaining([
         `/${source}/1/path/index.html`, // without slash in the end
@@ -251,6 +251,8 @@ describe("complex routes", () => {
         `/${source}/3/index.html`, // ignores hash
         `/${source}/4/index.html`, // ignores query
         `/${source}/5/index.html`, // link rel="alternate"
+        `/${source}/6/index.html`, // link rel="alternate"
+        `/${source}/6/subroute/index.html`, // link rel="alternate"
       ])
     );
   });
@@ -281,7 +283,7 @@ describe("complex routes with route filename", () => {
   beforeAll(() => snapRun(fs, { source, useRouteAsFileName: true }));
 
   test("crawls all links and saves as index.html in separate folders", () => {
-    expect(filesCreated()).toEqual(7);
+    expect(filesCreated()).toEqual(9);
     expect(names()).toEqual(
       expect.arrayContaining([
         `/${source}/1/path.html`, // without slash in the end
@@ -289,6 +291,8 @@ describe("complex routes with route filename", () => {
         `/${source}/3.html`, // ignores hash
         `/${source}/4.html`, // ignores query
         `/${source}/5.html`, // link rel="alternate"
+        `/${source}/6.html`, // link rel="alternate"
+        `/${source}/6/subroute.html`, // link rel="alternate"
       ])
     );
   });

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -192,6 +192,120 @@ describe("many pages", () => {
   });
 });
 
+describe("save as route name", () => {
+  const source = "tests/examples/many-pages";
+  const {
+    fs,
+    createReadStreamMock,
+    createWriteStreamMock,
+    filesCreated,
+    name,
+    names
+  } = mockFs();
+  beforeAll(() => snapRun(fs, { source, useRouteAsFileName: true }));
+
+  test("crawls all links and saves as index.html in separate folders", () => {
+    expect(filesCreated()).toEqual(7);
+    expect(names()).toEqual(
+      expect.arrayContaining([
+        `/${source}/1.html`, // without slash in the end
+        `/${source}/2.html`, // with slash in the end
+        `/${source}/3.html`, // ignores hash
+        `/${source}/4.html`, // ignores query
+        `/${source}/5.html`, // link rel="alternate"
+      ])
+    );
+  });
+  test("crawls / and saves as index.html to the same folder", () => {
+    expect(name(0)).toEqual(`/${source}/index.html`);
+  });
+  test("if there is more than page it crawls 404.html", () => {
+    expect(names()).toEqual(expect.arrayContaining([`/${source}/404.html`]));
+  });
+  test("copies (original) index.html to 200.html", () => {
+    expect(createReadStreamMock.mock.calls).toEqual([
+      [`/${source}/index.html`]
+    ]);
+    expect(createWriteStreamMock.mock.calls).toEqual([[`/${source}/200.html`]]);
+  });
+});
+
+describe("complex routes", () => {
+  const source = "tests/examples/complex-routes";
+  const {
+    fs,
+    createReadStreamMock,
+    createWriteStreamMock,
+    filesCreated,
+    name,
+    names
+  } = mockFs();
+  beforeAll(() => snapRun(fs, { source }));
+
+  test("crawls all links and saves as index.html in separate folders", () => {
+    expect(filesCreated()).toEqual(7);
+    expect(names()).toEqual(
+      expect.arrayContaining([
+        `/${source}/1/path/index.html`, // without slash in the end
+        `/${source}/2/path/to/index.html`, // with slash in the end
+        `/${source}/3/index.html`, // ignores hash
+        `/${source}/4/index.html`, // ignores query
+        `/${source}/5/index.html`, // link rel="alternate"
+      ])
+    );
+  });
+  test("crawls / and saves as index.html to the same folder", () => {
+    expect(name(0)).toEqual(`/${source}/index.html`);
+  });
+  test("if there is more than page it crawls 404.html", () => {
+    expect(names()).toEqual(expect.arrayContaining([`/${source}/404.html`]));
+  });
+  test("copies (original) index.html to 200.html", () => {
+    expect(createReadStreamMock.mock.calls).toEqual([
+      [`/${source}/index.html`]
+    ]);
+    expect(createWriteStreamMock.mock.calls).toEqual([[`/${source}/200.html`]]);
+  });
+});
+
+describe("complex routes with route filename", () => {
+  const source = "tests/examples/complex-routes";
+  const {
+    fs,
+    createReadStreamMock,
+    createWriteStreamMock,
+    filesCreated,
+    name,
+    names
+  } = mockFs();
+  beforeAll(() => snapRun(fs, { source, useRouteAsFileName: true }));
+
+  test("crawls all links and saves as index.html in separate folders", () => {
+    expect(filesCreated()).toEqual(7);
+    expect(names()).toEqual(
+      expect.arrayContaining([
+        `/${source}/1/path.html`, // without slash in the end
+        `/${source}/2/path/to.html`, // with slash in the end
+        `/${source}/3.html`, // ignores hash
+        `/${source}/4.html`, // ignores query
+        `/${source}/5.html`, // link rel="alternate"
+      ])
+    );
+  });
+  test("crawls / and saves as index.html to the same folder", () => {
+    expect(name(0)).toEqual(`/${source}/index.html`);
+  });
+  test("if there is more than page it crawls 404.html", () => {
+    expect(names()).toEqual(expect.arrayContaining([`/${source}/404.html`]));
+  });
+  test("copies (original) index.html to 200.html", () => {
+    expect(createReadStreamMock.mock.calls).toEqual([
+      [`/${source}/index.html`]
+    ]);
+    expect(createWriteStreamMock.mock.calls).toEqual([[`/${source}/200.html`]]);
+  });
+});
+
 describe("possible to disable crawl option", () => {
   const source = "tests/examples/many-pages";
   const {


### PR DESCRIPTION
Closes #2 

Proposing to add a new `useRouteAsFileName` option for users to choose whether they want their output files to all be named `index.html` or if they want to use the route name itself as a filename. For instance:

**Default behavior:**
- `/route` -> `/route/index.html`
- `/path/to/route` -> `path/to/route/index.html`

**Behavior with useRouteAsFileName**
- `/route` -> `/route.html`
- `/path/to/route` -> `path/to/route.html`

This should make it easier to deploy the pre-rendered apps to certain cdns, such as s3  + cloudfront and heroku, such as mentioned [here](https://github.com/stereobooster/react-snap/issues/493). 

Also added a test case where composite routes are used in order to make sure it would work as expected.