### PR TITLE
feat: receive timeout interval option

### DIFF
--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -240,6 +240,9 @@ const crawl = async opt => {
           sourcemapStore
         });
         beforeFetch && beforeFetch({ page, route });
+        
+        if(options.puppeteer.timeout) await page.setDefaultTimeout(options.puppeteer.timeout); 
+        
         await page.setUserAgent(options.userAgent);
         const tracker = createTracker(page);
         try {


### PR DESCRIPTION
<!--

If this a new feature make sure you discussed it before, otherwise it can stay unmerged for a long time. Check current roadmap https://github.com/natahouse/react-snap/issues/16

Please add tests for your code.

Just a reminder that you can install your fork via git, to do this you need to add the following to package JSON

{
  "dependencies": {
    "react-snap": "https://github.com/<name>/react-snap.git"
  }
}

You can specify a version:

{
  "dependencies": {
    "react-snap": "https://github.com/<name>/react-snap.git#<branch or tag or commit sha>"
  }
}

--->

### Description
I had some problems with timeout as there is a page that contains several requests and it was overflowing the default time of 30000ms. I looked for some ways to change this time and realized that it was not possible, so I thought about the possibility of this timeout interval being passed as an option for the puppeteer.

Thank you!